### PR TITLE
Final update for 2.62

### DIFF
--- a/NetScaler_OldScript_ChangeLog.txt
+++ b/NetScaler_OldScript_ChangeLog.txt
@@ -2,6 +2,25 @@
 #All Word related PowerShell functionality has been provided by Carl Webster
 #To contact, please use e-mail address info@barryschiffer.com
 
+#Version 2.62 18-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed $Null comparisons that were on the wrong side
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated Functions CheckWordPrereq and SendEmail to the latest version
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 2.61 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 

--- a/NetScaler_Script_v2_6_unsigned.ps1
+++ b/NetScaler_Script_v2_6_unsigned.ps1
@@ -7,9 +7,10 @@
 .SYNOPSIS
     Creates a complete inventory of a Citrix NetScaler configuration using Microsoft Word.
 .DESCRIPTION
-	Creates a complete inventory of a Citrix NetScaler configuration using Microsoft Word and PowerShell.
+	Creates a complete inventory of a Citrix NetScaler configuration using Microsoft Word 
+	and PowerShell.
 	Creates a Word document named after the Citrix NetScaler Configuration.
-	Document includes a Cover Page, Table of Contents and Footer.
+	Document includes a Cover Page, Table of Contents, and Footer.
 	Includes support for the following language versions of Microsoft Word:
 		Catalan
 		Chinese
@@ -25,7 +26,7 @@
 		Swedish
 		
 .PARAMETER CompanyAddress
-	Company Address to use for the Cover Page, if the Cover Page has the Address field.
+	Company Address to use for the Cover Page if the Cover Page has the Address field.
 	
 	The following Cover Pages have an Address field:
 		Banded (Word 2013/2016)
@@ -41,7 +42,7 @@
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CA.
 .PARAMETER CompanyEmail
-	Company Email to use for the Cover Page, if the Cover Page has the Email field.  
+	Company Email to use for the Cover Page if the Cover Page has the Email field.  
 	
 	The following Cover Pages have an Email field:
 		Facet (Word 2013/2016)
@@ -49,7 +50,7 @@
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CE.
 .PARAMETER CompanyFax
-	Company Fax to use for the Cover Page, if the Cover Page has the Fax field.  
+	Company Fax to use for the Cover Page if the Cover Page has the Fax field.  
 	
 	The following Cover Pages have a Fax field:
 		Contrast (Word 2010)
@@ -131,8 +132,6 @@
 .PARAMETER PDF
 	SaveAs PDF file instead of DOCX file.
 	This parameter is disabled by default.
-	For Word 2007, the Microsoft add-in for saving as a PDF muct be installed.
-	For Word 2007, please see http://www.microsoft.com/en-us/download/details.aspx?id=9943
 	The PDF file is roughly 5X to 10X larger than the DOCX file.
 .PARAMETER MSWord
 	SaveAs DOCX file
@@ -140,8 +139,8 @@
 .PARAMETER AddDateTime
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 	This parameter is disabled by default.
 .PARAMETER Folder
 	Specifies the optional output folder to save the output report. 
@@ -179,8 +178,10 @@
 	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry Schiffer" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry Schiffer"
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry 
+	Schiffer" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry 
+	Schiffer"
 	$env:username = Administrator
 
 	Barry Schiffer for the Company Name.
@@ -190,22 +191,26 @@
 	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -PDF
 	
 	Will use all default values and save the document as a PDF file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry Schiffer" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry Schiffer"
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry 
+	Schiffer" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry 
+	Schiffer"
 	$env:username = Administrator
 
 	Barry Schiffer for the Company Name.
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CompanyName "Barry Schiffer Consulting" -CoverPage "Mod" -UserName "Barry Schiffer"
+	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CompanyName "Barry Schiffer 
+	Consulting" -CoverPage "Mod" -UserName "Barry Schiffer"
 
 	Will use:
 		Barry Schiffer Consulting for the Company Name.
 		Mod for the Cover Page format.
 		Barry Schiffer for the User Name.
 .EXAMPLE
-	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CN "Barry Schiffer Consulting" -CP "Mod" -UN "Barry Schiffer"
+	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CN "Barry Schiffer Consulting" -CP 
+	"Mod" -UN "Barry Schiffer"
 
 	Will use:
 		Barry Schiffer Consulting for the Company Name (alias CN).
@@ -215,8 +220,10 @@
 	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -AddDateTime
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry Schiffer" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry Schiffer"
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry 
+	Schiffer" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry 
+	Schiffer"
 	$env:username = Administrator
 
 	Barry Schiffer for the Company Name.
@@ -225,14 +232,16 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be Script_Template_2020-06-01_1800.docx
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	Output filename will be Script_Template_2022-06-01_1800.docx
 .EXAMPLE
 	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -PDF -AddDateTime
 	
 	Will use all default values and save the document as a PDF file.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry Schiffer" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry Schiffer"
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Barry 
+	Schiffer" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Barry 
+	Schiffer"
 	$env:username = Administrator
 
 	Barry Schiffer for the Company Name.
@@ -241,14 +250,12 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be Script_Template_2020-06-01_1800.PDF
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	Output filename will be Script_Template_2022-06-01_1800.PDF
 .EXAMPLE
-	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CompanyName "Sherlock Holmes Consulting"
-	-CoverPage Exposure -UserName "Dr. Watson"
-	-CompanyAddress "221B Baker Street, London, England"
-	-CompanyFax "+44 1753 276600"
-	-CompanyPhone "+44 1753 276200"
+	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CompanyName "Sherlock Holmes 
+	Consulting" -CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker 
+	Street, London, England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 	
 	Will use:
 		Sherlock Holmes Consulting for the Company Name.
@@ -258,9 +265,9 @@
 		+44 1753 276600 for the Company Fax.
 		+44 1753 276200 for the Company Phone.
 .EXAMPLE
-	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CompanyName "Sherlock Holmes Consulting"
-	-CoverPage Facet -UserName "Dr. Watson"
-	-CompanyEmail SuperSleuth@SherlockHolmes.com
+	PS C:\PSScript .\NetScaler_Script_v2_6.ps1 -CompanyName "Sherlock Holmes 
+	Consulting" -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail 
+	SuperSleuth@SherlockHolmes.com
 
 	Will use:
 		Sherlock Holmes Consulting for the Company Name.
@@ -282,44 +289,92 @@
 	
 	Output file will be saved in the path \\FileServer\ShareName
 .EXAMPLE
-	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer mail.domain.tld
-	-From XDAdmin@domain.tld -To ITGroup@domain.tld	
+	PS C:\PSScript >.\NetScaler_Script_v2_6.ps1 -Dev -ScriptInfo -Log
 	
-	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
-	Webster" or 
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	$env:username = Administrator
+	Creates the default report.
+	
+	Creates a text file named NSInventoryScriptErrors_yyyyMMddTHHmmssffff.txt that 
+	contains up to the last 250 errors reported by the script.
+	
+	Creates a text file named NSInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that 
+	contains all the script parameters and other basic information.
+	
+	Creates a text file for transcript logging named 
+	NSDocScriptTranscript_yyyyMMddTHHmmssffff.txt.
+.EXAMPLE
+	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer mail.domain.tld -From 
+	XDAdmin@domain.tld -To ITGroup@domain.tld	
 
-	Carl Webster for the Company Name.
-	Sideline for the Cover Page format.
-	Administrator for the User Name.
-	
 	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, 
 	sending to ITGroup@domain.tld.
-	
-	The script will use the default SMTP port 25 and will not use SSL.
-	
-	If the current user's credentials are not valid to send email, 
+
+	The script will use the default SMTP port 25 and does not use SSL.
+
+	If the current user's credentials are not valid to send an email, 
 	the user will be prompted to enter valid credentials.
 .EXAMPLE
-	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
-	-UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com	
-	
-	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
-	Webster" or 
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	$env:username = Administrator
+	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer mailrelay.domain.tld -From 
+	Anonymous@domain.tld -To ITGroup@domain.tld	
 
-	Carl Webster for the Company Name.
-	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	***SENDING UNAUTHENTICATED EMAIL***
+
+	The script will use the email server mailrelay.domain.tld, sending from 
+	anonymous@domain.tld, sending to ITGroup@domain.tld.
+
+	To send unauthenticated email using an email relay server requires the From email account 
+	to use the name Anonymous.
+
+	The script will use the default SMTP port 25 and does not use SSL.
 	
+	***GMAIL/G SUITE SMTP RELAY***
+	https://support.google.com/a/answer/2956491?hl=en
+	https://support.google.com/a/answer/176600?hl=en
+
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	***GMAIL/G SUITE SMTP RELAY***
+
+	The script generates an anonymous, secure password for the anonymous@domain.tld 
+	account.
+.EXAMPLE
+	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer 
+	labaddomain-com.mail.protection.outlook.com -UseSSL -From 
+	SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com	
+
+	***OFFICE 365 Example***
+
+	https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
+	
+	This uses Option 2 from the above link.
+	
+	***OFFICE 365 Example***
+
+	The script will use the email server labaddomain-com.mail.protection.outlook.com, 
+	sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+
+	The script will use the default SMTP port 25 and will use SSL.
+.EXAMPLE
+	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer smtp.office365.com -SmtpPort 
+	587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com	
+
 	The script will use the email server smtp.office365.com on port 587 using SSL, 
 	sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+
+	If the current user's credentials are not valid to send an email, 
+	the user will be prompted to enter valid credentials.
+.EXAMPLE
+	PS C:\PSScript > .\NetScaler_Script_v2_6.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
+	-UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com	
+
+	*** NOTE ***
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	*** NOTE ***
 	
-	If the current user's credentials are not valid to send email, 
+	The script will use the email server smtp.gmail.com on port 587 using SSL, 
+	sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+
+	If the current user's credentials are not valid to send an email, 
 	the user will be prompted to enter valid credentials.
 .INPUTS
 	None.  You cannot pipe objects to this script.
@@ -328,9 +383,9 @@
 	This script creates a Word or PDF document.
 .NOTES
 	NAME: NetScaler_Script_v2_6_unsigned.ps1
-	VERSION: 2.61
+	VERSION: 2.62
 	AUTHOR: Carl Webster, Michael B. Smith, Iain Brighton, Jeff Wouters, Barry Schiffer
-	LASTEDIT: December 17, 2019
+	LASTEDIT: February 18, 2022
 #>
 
 #endregion Support
@@ -443,6 +498,25 @@ Param(
 	AUTHOR NetScaler script: Barry Schiffer
     AUTHOR NetScaler script functions: Iain Brighton
     AUTHOR Script template: Carl Webster, Michael B. Smith, Iain Brighton, Jeff Wouters
+#Version 2.62 18-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed $Null comparisons that were on the wrong side
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated Functions CheckWordPrereq and SendEmail to the latest version
+#	Updated the help text
+#	Updated the ReadMe file
+#
 .Release Notes V2.61
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -534,6 +608,59 @@ Param(
 
 #>
 
+
+Function AbortScript
+{
+	If($MSWord -or $PDF)
+	{
+		Write-Verbose "$(Get-Date -Format G): System Cleanup"
+		If(Test-Path variable:global:word)
+		{
+			$Script:Word.quit()
+			[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
+			Remove-Variable -Name word -Scope Global 4>$Null
+		}
+	}
+	[gc]::collect() 
+	[gc]::WaitForPendingFinalizers()
+
+	If($MSWord -or $PDF)
+	{
+		#is the winword Process still running? kill it
+
+		#find out our session (usually "1" except on TS/RDC or Citrix)
+		$SessionID = (Get-Process -PID $PID).SessionId
+
+		#Find out if winword running in our session
+		$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) | Select-Object -Property Id 
+		If( $wordprocess -and $wordprocess.Id -gt 0)
+		{
+			Write-Verbose "$(Get-Date -Format G): WinWord Process is still running. Attempting to stop WinWord Process # $($wordprocess.Id)"
+			Stop-Process $wordprocess.Id -EA 0
+		}
+	}
+	
+	Write-Verbose "$(Get-Date -Format G): Script has been aborted"
+	#stop transcript logging
+	If($Log -eq $True) 
+	{
+		If($Script:StartLog -eq $True) 
+		{
+			try 
+			{
+				Stop-Transcript | Out-Null
+				Write-Verbose "$(Get-Date -Format G): $Script:LogPath is ready for use"
+			} 
+			catch 
+			{
+				Write-Verbose "$(Get-Date -Format G): Transcript/log stop failed"
+			}
+		}
+	}
+	$ErrorActionPreference = $SaveEAPreference
+	Exit
+}
+
 Set-StrictMode -Version 2
 
 #force -verbose on
@@ -546,7 +673,7 @@ If($Log)
 {
 	#start transcript logging
 	$Script:ThisScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
-	$Script:LogPath = "$Script:ThisScriptPath\NSDocScriptTranscript_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
+	$Script:LogPath = "$Script:ThisScriptPath\NSDocScriptTranscript_$(Get-Date -f FileDateTime).txt"
 	
 	try 
 	{
@@ -564,10 +691,10 @@ If($Log)
 If($Dev)
 {
 	$Error.Clear()
-	$Script:DevErrorFile = "$($pwd.Path)\NSInventoryScriptErrors_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
+	$Script:DevErrorFile = "$($pwd.Path)\NSInventoryScriptErrors_$(Get-Date -f FileDateTime).txt"
 }
 
-If($MSWord -eq $Null)
+If($Null -eq $MSWord)
 {
 	If($PDF)
 	{
@@ -598,11 +725,11 @@ Else
 {
 	$ErrorActionPreference = $SaveEAPreference
 	Write-Verbose "$(Get-Date): Unable to determine output parameter"
-	If($MSWord -eq $Null)
+	If($Null -eq $MSWord)
 	{
 		Write-Verbose "$(Get-Date): MSWord is Null"
 	}
-	ElseIf($PDF -eq $Null)
+	ElseIf($Null -eq $PDF)
 	{
 		Write-Verbose "$(Get-Date): PDF is Null"
 	}
@@ -612,7 +739,7 @@ Else
 		Write-Verbose "$(Get-Date): PDF is $($PDF)"
 	}
 	Write-Error "Unable to determine output parameter.  Script cannot continue"
-	Exit
+	AbortScript
 }
 
 If($Folder -ne "")
@@ -631,14 +758,14 @@ If($Folder -ne "")
 		{
 			#it exists but it is a file not a folder
 			Write-Error "Folder $Folder is a file, not a folder.  Script cannot continue"
-			Exit
+			AbortScript
 		}
 	}
 	Else
 	{
 		#does not exist
 		Write-Error "Folder $Folder does not exist.  Script cannot continue"
-		Exit
+		AbortScript
 	}
 }
 
@@ -750,7 +877,8 @@ Function SetWordHashTable
 		{
 			'ca-'	{ 'Taula automática 2'; Break }
 			'da-'	{ 'Automatisk tabel 2'; Break }
-			'de-'	{ 'Automatische Tabelle 2'; Break }
+			#'de-'	{ 'Automatische Tabelle 2'; Break }
+			'de-'	{ 'Automatisches Verzeichnis 2'; Break } #changed 18-feb-2022 rene bigler
 			'en-'	{ 'Automatic Table 2'; Break }
 			'es-'	{ 'Tabla automática 2'; Break }
 			'fi-'	{ 'Automaattinen taulukko 2'; Break }
@@ -1103,20 +1231,29 @@ Function CheckWordPrereq
 	If((Test-Path  REGISTRY::HKEY_CLASSES_ROOT\Word.Application) -eq $False)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Host "`n`n`t`tThis script directly outputs to Microsoft Word, please install Microsoft Word`n`n"
-		Exit
+		
+		If(($MSWord -eq $False) -and ($PDF -eq $True))
+		{
+			Write-Host "`n`n`t`tThis script uses Microsoft Word's SaveAs PDF function, please install Microsoft Word`n`n"
+			AbortScript
+		}
+		Else
+		{
+			Write-Host "`n`n`t`tThis script directly outputs to Microsoft Word, please install Microsoft Word`n`n"
+			AbortScript
+		}
 	}
 
 	#find out our session (usually "1" except on TS/RDC or Citrix)
 	$SessionID = (Get-Process -PID $PID).SessionId
 	
 	#Find out if winword is running in our session
-	[bool]$wordrunning = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) -ne $Null
+	[bool]$wordrunning = $null –ne ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID})
 	If($wordrunning)
 	{
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Host "`n`n`tPlease close all instances of Microsoft Word before running this report.`n`n"
-		Exit
+		AbortScript
 	}
 }
 
@@ -1270,25 +1407,6 @@ Function WriteWordLine
 	{
 		$Script:Selection.TypeParagraph()
 	}
-}
-
-Function AbortScript
-{
-	If($MSWord -or $PDF)
-	{
-		$Script:Word.quit()
-		Write-Verbose "$(Get-Date): System Cleanup"
-		[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
-		If(Test-Path variable:global:word)
-		{
-			Remove-Variable -Name word -Scope Global 4>$Null
-		}
-	}
-	[gc]::collect() 
-	[gc]::WaitForPendingFinalizers()
-	Write-Verbose "$(Get-Date): Script has been aborted"
-	$ErrorActionPreference = $SaveEAPreference
-	Exit
 }
 
 Function FindWordDocumentEnd
@@ -1823,7 +1941,7 @@ Function SetupWord
 		Write-Warning "The Word object could not be created.  You may need to repair your Word installation."
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Error "`n`n`t`tThe Word object could not be created.  You may need to repair your Word installation.`n`n`t`tScript cannot continue.`n`n"
-		Exit
+		AbortScript
 	}
 
 	Write-Verbose "$(Get-Date): Determine Word language value"
@@ -2297,41 +2415,10 @@ Function SaveandCloseDocumentandShutdownWord
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Closing Word"
+	Write-Verbose "$(Get-Date -Format G): Closing Word"
 	$Script:Doc.Close()
 	$Script:Word.Quit()
-	If($PDF)
-	{
-		[int]$cnt = 0
-		While(Test-Path $Script:FileName1)
-		{
-			$cnt++
-			If($cnt -gt 1)
-			{
-				Write-Verbose "$(Get-Date): Waiting another 10 seconds to allow Word to fully close (try # $($cnt))"
-				Start-Sleep -Seconds 10
-				$Script:Word.Quit()
-				If($cnt -gt 2)
-				{
-					#kill the winword process
-
-					#find out our session (usually "1" except on TS/RDC or Citrix)
-					$SessionID = (Get-Process -PID $PID).SessionId
-					
-					#Find out if winword is running in our session
-					$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}).Id
-					If($wordprocess -gt 0)
-					{
-						Write-Verbose "$(Get-Date): Attempting to stop WinWord process # $($wordprocess)"
-						Stop-Process $wordprocess -EA 0
-					}
-				}
-			}
-			Write-Verbose "$(Get-Date): Attempting to delete $($Script:FileName1) since only $($Script:FileName2) is needed (try # $($cnt))"
-			Remove-Item $Script:FileName1 -EA 0 4>$Null
-		}
-	}
-	Write-Verbose "$(Get-Date): System Cleanup"
+	Write-Verbose "$(Get-Date -Format G): System Cleanup"
 	[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 	If(Test-Path variable:global:word)
 	{
@@ -2341,18 +2428,17 @@ Function SaveandCloseDocumentandShutdownWord
 	[gc]::collect() 
 	[gc]::WaitForPendingFinalizers()
 	
-	#is the winword process still running? kill it
+	#is the winword Process still running? kill it
 
 	#find out our session (usually "1" except on TS/RDC or Citrix)
 	$SessionID = (Get-Process -PID $PID).SessionId
 
-	#Find out if winword is running in our session
-	$wordprocess = $Null
-	$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}).Id
-	If($null -ne $wordprocess -and $wordprocess -gt 0)
+	#Find out if winword running in our session
+	$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) | Select-Object -Property Id 
+	If( $wordprocess -and $wordprocess.Id -gt 0)
 	{
-		Write-Verbose "$(Get-Date): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess)"
-		Stop-Process $wordprocess -EA 0
+		Write-Verbose "$(Get-Date -Format G): WinWord Process is still running. Attempting to stop WinWord Process # $($wordprocess.Id)"
+		Stop-Process $wordprocess.Id -EA 0
 	}
 }
 
@@ -2881,7 +2967,7 @@ Write-Verbose "$(Get-Date): NetScaler file : $SourceFile"
 $File = Get-Content $SourceFile
 
 #added by Carl Webster 24-May-2014
-If(!$? -or $File -eq $Null)
+If(!$? -or $Null -eq $File)
 {
 	Write-Error "`n`n`t`tUnable to read the NetScaler ns.conf file.`n`n`t`tScript cannot continue.`n`n"
 	AbortScript
@@ -4640,7 +4726,7 @@ if($ContentSwitches.Length -le 0) { WriteWordLine 0 0 "No Content Switch has bee
         $ContentSwitchBindMatches = Get-StringWithProperty -SearchString $ContentSwitchBind -Like "bind cs vserver $ContentSwitchDisplayNameWithQuotes *";
 
         ## Check if we have any specific Content Switch bind matches
-        if ($ContentSwitchBindMatches -eq $null -or $ContentSwitchBindMatches.Length -le 0) {
+        if ($Null -eq $ContentSwitchBindMatches -or $ContentSwitchBindMatches.Length -le 0) {
             WriteWordLine 0 0 "No Policy has been configured for this Content Switch"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -4875,7 +4961,7 @@ if($LoadBalancers.Length -le 0) { WriteWordLine 0 0 "No Load Balancer has been c
 
         $LoadBalancerBindMatches = Get-StringWithProperty -SearchString $LoadbalancerBind -Like "bind lb vserver $LoadBalancerDisplayNameWithQoutes *";
         ## Check if we have any specific load balancer bind matches
-        if ($LoadBalancerBindMatches -eq $null -or $LoadBalancerBindMatches.Length -le 0) {
+        if ($Null -eq $LoadBalancerBindMatches -or $LoadBalancerBindMatches.Length -le 0) {
             WriteWordLine 0 0 "No Service (Group) has been configured for this Load Balancer"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -5093,7 +5179,7 @@ if($Services.Length -le 0) { WriteWordLine 0 0 "No Service has been configured"}
 
         $ServiceBindMatches = Get-StringWithProperty -SearchString $ServiceBind -Like "bind service $ServiceDisplayNameWithQuotes *";
         ## Check if we have any specific Service bind matches
-        if ($ServiceBindMatches -eq $null -or $ServiceBindMatches.Length -le 0) {
+        if ($Null -eq $ServiceBindMatches -or $ServiceBindMatches.Length -le 0) {
             WriteWordLine 0 0 "No Monitor has been configured for this Service"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -5279,7 +5365,7 @@ if($ServiceGroups.Length -le 0) { WriteWordLine 0 0 "No Service Group has been c
 
         WriteWordLine 3 0 "Monitor"     
 
-        if ($ServicegroupBindMatches -eq $null -or $ServicegroupBindMatches.Length -le 0) {
+        if ($Null -eq $ServicegroupBindMatches -or $ServicegroupBindMatches.Length -le 0) {
             WriteWordLine 0 0 "No Monitor has been configured for this Service Group"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -5641,7 +5727,7 @@ WriteWordLine 0 0 " "
 WriteWordLine 3 0 "Global Settings Secure Ticket Authority Configuration"
 $STAMATCHES = Get-StringWithProperty -SearchString $Bind -Like "bind vpn global -staServer *";
 
-if ($STAMATCHES -eq $null -or $STAMatches.Length -le 0) {
+if ($Null -eq $STAMATCHES -or $STAMatches.Length -le 0) {
             WriteWordLine 0 0 "No Secure Ticket Authority has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -5669,7 +5755,7 @@ WriteWordLine 0 0 " "
 WriteWordLine 3 0 "Global Settings App Controller Configuration"
 $APPCMATCHES = Get-StringWithProperty -SearchString $Bind -Like "bind vpn global -appController *";
 
-if ($APPCMATCHES -eq $null -or $APPCMatches.Length -le 0) {
+if ($Null -eq $APPCMATCHES -or $APPCMatches.Length -le 0) {
             WriteWordLine 0 0 "No App Controller has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6180,7 +6266,7 @@ WriteWordLine 2 0 "NetScaler Custom Pattern Set Policies"
 Write-Verbose "$(Get-Date): `tTable: NetScaler Custom Pattern Set Policies"
 $PATSET1 = Get-StringWithProperty -SearchString $Add -Like 'add policy patset *';
 
-if ($PATSET1 -eq $null -or $PATSET1.Length -le 0) {
+if ($Nul -eq $PATSET1 -or $PATSET1.Length -le 0) {
         WriteWordLine 0 0 "No Custom Pattern Set Policy has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6209,7 +6295,7 @@ WriteWordLine 2 0 "NetScaler Custom Responder Policies"
 Write-Verbose "$(Get-Date): `tTable: NetScaler Custom Responder Policies"
 $POLICY = Get-StringWithProperty -SearchString $Add -Like 'add responder policy *';
 
-if ($POLICY -eq $null -or $POLICY.Length -le 0) {
+if ($Null -eq $POLICY -or $POLICY.Length -le 0) {
         WriteWordLine 0 0 "No Custom Responder Policy has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6240,7 +6326,7 @@ Write-Verbose "$(Get-Date): `tTable: NetScaler Custom Rewrite Policies"
 
 $POLRW = Get-StringWithProperty -SearchString $Add -Like 'add rewrite policylabel *';
 
-if ($POLRW -eq $null -or $POLRW.Length -le 0) {
+if ($Null -eq $POLRW -or $POLRW.Length -le 0) {
         WriteWordLine 0 0 "No Custom Rewrite Policy has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6283,7 +6369,7 @@ WriteWordLine 2 0 "NetScaler Custom Pattern Set Action"
 Write-Verbose "$(Get-Date): `tTable: NetScaler Custom Pattern Set Action"
 $ACTPATSET1 = Get-StringWithProperty -SearchString $Add -Like 'add action patset *';
 
-if ($ACTPATSET1 -eq $null -or $ACTPATSET1.Length -le 0) {
+if ($Null -eq $ACTPATSET1 -or $ACTPATSET1.Length -le 0) {
         WriteWordLine 0 0 "No Custom Pattern Set Action has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6314,7 +6400,7 @@ WriteWordLine 2 0 "NetScaler Responder Action"
 Write-Verbose "$(Get-Date): `tTable: NetScaler Custom Responder Action"
 $ACTRES = Get-StringWithProperty -SearchString $Add -Like 'add responder action *';
 
-if ($ACTRES -eq $null -or $ACTRES.Length -le 0) {
+if ($Null -eq $ACTRES -or $ACTRES.Length -le 0) {
         WriteWordLine 0 0 "No Custom Responder Action has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6348,7 +6434,7 @@ WriteWordLine 2 0 "NetScaler Custom Rewrite Action"
 Write-Verbose "$(Get-Date): `tTable: NetScaler Custom Rewrite Action"
 $ACTRW = Get-StringWithProperty -SearchString $Add -Like 'add rewrite action *';
 
-if ($ACTRW -eq $null -or $ACTRW.Length -le 0) {
+if ($Null -eq $ACTRW -or $ACTRW.Length -le 0) {
         WriteWordLine 0 0 "No Custom Rewrite Policy has been configured"
         } else {
             ## IB - Use an array of hashtable to store the rows
@@ -6475,15 +6561,16 @@ $selection.InsertNewPage()
 #region email function
 Function SendEmail
 {
-	Param([string]$Attachments)
-	Write-Verbose "$(Get-Date): Prepare to email"
-	
+	Param([array]$Attachments)
+	Write-Verbose "$(Get-Date -Format G): Prepare to email"
+
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
 	$emailBody = @"
 Hello, <br />
 <br />
 $Script:Title is attached.
+
 "@ 
 
 	If($Dev)
@@ -6492,66 +6579,105 @@ $Script:Title is attached.
 	}
 
 	$error.Clear()
-
-	If($UseSSL)
+	
+	If($From -Like "anonymous@*")
 	{
-		Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-		-UseSSL *>$Null
-	}
-	Else
-	{
-		Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
-	}
-
-	$e = $error[0]
-
-	If($e.Exception.ToString().Contains("5.7.57"))
-	{
-		#The server response was: 5.7.57 SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-		Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
-
-		If($Dev)
-		{
-			Out-File -FilePath $Script:DevErrorFile -InputObject $error -Append 4>$Null
-		}
-
-		$error.Clear()
-
-		$emailCredentials = Get-Credential -Message "Enter the email account and password to send email"
+		#https://serverfault.com/questions/543052/sending-unauthenticated-mail-through-ms-exchange-with-powershell-windows-server
+		$anonUsername = "anonymous"
+		$anonPassword = ConvertTo-SecureString -String "anonymous" -AsPlainText -Force
+		$anonCredentials = New-Object System.Management.Automation.PSCredential($anonUsername,$anonPassword)
 
 		If($UseSSL)
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-UseSSL -credential $emailCredentials *>$Null 
+			-UseSSL -credential $anonCredentials *>$Null 
 		}
 		Else
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-credential $emailCredentials *>$Null 
+			-credential $anonCredentials *>$Null 
 		}
-
-		$e = $error[0]
-
-		If($? -and $Null -eq $e)
+		
+		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+			Write-Verbose "$(Get-Date -Format G): Email successfully sent using anonymous credentials"
 		}
-		Else
+		ElseIf(!$?)
 		{
-			Write-Verbose "$(Get-Date): Email was not sent:"
-			Write-Warning "$(Get-Date): Exception: $e.Exception" 
+			$e = $error[0]
+
+			Write-Verbose "$(Get-Date -Format G): Email was not sent:"
+			Write-Warning "$(Get-Date -Format G): Exception: $e.Exception" 
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): Email was not sent:"
-		Write-Warning "$(Get-Date): Exception: $e.Exception" 
+		If($UseSSL)
+		{
+			Write-Verbose "$(Get-Date -Format G): Trying to send email using current user's credentials with SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+			-UseSSL *>$Null
+		}
+		Else
+		{
+			Write-Verbose  "$(Get-Date -Format G): Trying to send email using current user's credentials without SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
+		}
+
+		If(!$?)
+		{
+			$e = $error[0]
+			
+			#error 5.7.57 is O365 and error 5.7.0 is gmail
+			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
+			{
+				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
+				Write-Verbose "$(Get-Date -Format G): Current user's credentials failed. Ask for usable credentials."
+
+				If($Dev)
+				{
+					Out-File -FilePath $Script:DevErrorFile -InputObject $error -Append 4>$Null
+				}
+
+				$error.Clear()
+
+				$emailCredentials = Get-Credential -UserName $From -Message "Enter the password to send email"
+
+				If($UseSSL)
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-UseSSL -credential $emailCredentials *>$Null 
+				}
+				Else
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-credential $emailCredentials *>$Null 
+				}
+
+				If($?)
+				{
+					Write-Verbose "$(Get-Date -Format G): Email successfully sent using new credentials"
+				}
+				ElseIf(!$?)
+				{
+					$e = $error[0]
+
+					Write-Verbose "$(Get-Date -Format G): Email was not sent:"
+					Write-Warning "$(Get-Date -Format G): Exception: $e.Exception" 
+				}
+			}
+			Else
+			{
+				Write-Verbose "$(Get-Date -Format G): Email was not sent:"
+				Write-Warning "$(Get-Date -Format G): Exception: $e.Exception" 
+			}
+		}
 	}
 }
 #endregion

--- a/NetScaler_V2.6_ReadMe.rtf
+++ b/NetScaler_V2.6_ReadMe.rtf
@@ -1,21 +1,21 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \fswiss\fcharset0\fprq2{\*\panose 00000000000000000000}Segoe UI;}{\f44\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \fswiss\fcharset0\fprq2{\*\panose 020b0502040204020203}Segoe UI;}{\f44\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f45\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\f46\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f48\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f49\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f50\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\f51\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f52\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f53\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f65\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}
-{\f66\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}{\f68\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f69\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f70\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}
-{\f71\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}{\f72\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f73\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f385\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
-{\f386\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f388\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f389\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f392\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
-{\f393\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f415\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f416\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f418\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}
-{\f419\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\f420\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f421\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f422\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
-{\f423\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\f475\fbidi \fswiss\fcharset238\fprq2 Segoe UI CE;}{\f476\fbidi \fswiss\fcharset204\fprq2 Segoe UI Cyr;}{\f478\fbidi \fswiss\fcharset161\fprq2 Segoe UI Greek;}
-{\f479\fbidi \fswiss\fcharset162\fprq2 Segoe UI Tur;}{\f480\fbidi \fswiss\fcharset177\fprq2 Segoe UI (Hebrew);}{\f481\fbidi \fswiss\fcharset178\fprq2 Segoe UI (Arabic);}{\f482\fbidi \fswiss\fcharset186\fprq2 Segoe UI Baltic;}
-{\f483\fbidi \fswiss\fcharset163\fprq2 Segoe UI (Vietnamese);}{\f485\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f486\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f488\fbidi \froman\fcharset161\fprq2 Cambria Greek;}
-{\f489\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\f492\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f493\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f881\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\f882\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f884\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f885\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f886\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
+{\f887\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f888\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f889\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f901\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}
+{\f902\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}{\f904\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f905\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f906\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}
+{\f907\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}{\f908\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f909\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f1221\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
+{\f1222\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f1224\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f1225\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f1228\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
+{\f1229\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f1251\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f1252\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f1254\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}
+{\f1255\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}{\f1256\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f1257\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f1258\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
+{\f1259\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\f1311\fbidi \fswiss\fcharset238\fprq2 Segoe UI CE;}{\f1312\fbidi \fswiss\fcharset204\fprq2 Segoe UI Cyr;}{\f1314\fbidi \fswiss\fcharset161\fprq2 Segoe UI Greek;}
+{\f1315\fbidi \fswiss\fcharset162\fprq2 Segoe UI Tur;}{\f1316\fbidi \fswiss\fcharset177\fprq2 Segoe UI (Hebrew);}{\f1317\fbidi \fswiss\fcharset178\fprq2 Segoe UI (Arabic);}{\f1318\fbidi \fswiss\fcharset186\fprq2 Segoe UI Baltic;}
+{\f1319\fbidi \fswiss\fcharset163\fprq2 Segoe UI (Vietnamese);}{\f1321\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f1322\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f1324\fbidi \froman\fcharset161\fprq2 Cambria Greek;}
+{\f1325\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\f1328\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f1329\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -170,17 +170,18 @@ FollowedHyperlink;}}{\*\listtable{\list\listtemplateid1413223892\listhybrid{\lis
 \listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid713583465\listoverridecount0\ls4}{\listoverride\listid506208892\listoverridecount0\ls5}
 {\listoverride\listid667366462\listoverridecount0\ls6}{\listoverride\listid222764052\listoverridecount0\ls7}{\listoverride\listid339236872\listoverridecount0\ls8}{\listoverride\listid147792712\listoverridecount0\ls9}{\listoverride\listid1618828663
 \listoverridecount0\ls10}{\listoverride\listid1485508831\listoverridecount0\ls11}{\listoverride\listid1681394709\listoverridecount0\ls12}{\listoverride\listid340086015\listoverridecount0\ls13}{\listoverride\listid346911377\listoverridecount0\ls14}}
-{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp1\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp1\itap0\li0\ri0\sb0\sa420}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid1925247\rsid3830441\rsid5196246\rsid7095228
-\rsid7892711\rsid9072594\rsid9980162\rsid11485054\rsid11488686\rsid12284731\rsid13451403\rsid13987238\rsid14096595\rsid14697282\rsid15609505\rsid16011537}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
-\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Barry Schiffer}{\operator Webster}{\creatim\yr2014\mo7\dy21\hr17\min32}{\revtim\yr2019\mo12\dy17\hr10\min4}{\version7}{\edmins19}{\nofpages4}{\nofwords651}{\nofchars3712}{\nofcharsws4355}{\vern119}}
-{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp1\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp1\itap0\li0\ri0\sb0\sa420}{\pgp\ipgp4\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid1538239\rsid1925247\rsid3830441\rsid5196246
+\rsid7095228\rsid7892711\rsid9072594\rsid9980162\rsid11485054\rsid11488686\rsid12284731\rsid13451403\rsid13987238\rsid14096595\rsid14697282\rsid15609505\rsid16011537}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
+\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Barry Schiffer}{\operator Carl Webster}{\creatim\yr2014\mo7\dy21\hr17\min32}{\revtim\yr2022\mo2\dy18\hr7\min40}{\version8}{\edmins29}{\nofpages15}{\nofwords4083}{\nofchars23278}{\nofcharsws27307}
+{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\hyphhotz425\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120
-\dghorigin1701\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\*\pnseclvl1
-\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
-\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
-{\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid13451403 \hich\af31506\dbch\af31505\loch\f31506 NetScaler Version }
-{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 2.0}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af31506\dbch\af31505\loch\f31506  Documentation Script ReadMe
+\dghorigin1701\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDaysDQzMzEzsjSwtDAwNTRX0lEKTi0uzszPAykwrAUAvpm1yywAAAA=}}\ltrpar \sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang 
+{\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}
+{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9
+\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid13451403 \hich\af31506\dbch\af31505\loch\f31506 NetScaler Version }{\rtlch\fcs1 \ab\af44\afs28 
+\ltrch\fcs0 \b\fs28\cf21\insrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 2.0}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 \hich\af31506\dbch\af31505\loch\f31506  Documentation Script ReadMe
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
 \par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 NOTE: This script ha}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid11485054 \hich\af37\dbch\af31505\loch\f37 s been tested with PowerShell V3}{\rtlch\fcs1 
@@ -211,19 +212,19 @@ It will NOT work with PowerShell V1}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\ins
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid12284731 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 Functionality v2
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5196246 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
-\ab\af0 \ltrch\fcs0 \b\insrsid5196246\charrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 Fi\hich\af31506\dbch\af31505\loch\f31506 x\hich\af31506\dbch\af31505\loch\f31506 ed in 2.61
+\ab\af0 \ltrch\fcs0 \b\insrsid5196246\charrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 Fixed in 2.61
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid5196246 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls14\rin0\lin720\itap0\pararsid5196246 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 Fix Swedish Table of Contents (Thanks to Johan Kallio)
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af2 \ltrch\fcs0 \f2\fs22\insrsid5196246 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls14\ilvl1\rin0\lin1440\itap0\pararsid5196246 {\rtlch\fcs1 \af0 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f2\fs22\insrsid5196246 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls14\ilvl1\rin0\lin1440\itap0\pararsid5196246 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 From 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f10\fs22\insrsid5196246 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}\pard \ltrpar\ql \fi-360\li2160\ri0\nowidctlpar\wrapdefault\faauto\ls14\ilvl2\rin0\lin2160\itap0\pararsid5196246 {\rtlch\fcs1 
 \af0 \ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 'sv-'\tab \{\hich\f31506  'Automatisk inneh\'e5\loch\f31506 \hich\f31506 llsf\'f6\loch\f31506 rteckning2'; Break \}
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af2 \ltrch\fcs0 \f2\fs22\insrsid5196246 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls14\ilvl1\rin0\lin1440\itap0\pararsid5196246 {\rtlch\fcs1 \af0 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f2\fs22\insrsid5196246 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls14\ilvl1\rin0\lin1440\itap0\pararsid5196246 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 To
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f10\fs22\insrsid5196246 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}\pard \ltrpar\ql \fi-360\li2160\ri0\nowidctlpar\wrapdefault\faauto\ls14\ilvl2\rin0\lin2160\itap0\pararsid5196246 {\rtlch\fcs1 
 \af0 \ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 'sv-'\tab \{\hich\f31506  'Automatisk inneh\'e5\loch\f31506 \hich\f31506 llsf\'f6\loch\f31506 rteckn2'; Break \}
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid5196246 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls14\rin0\lin720\itap0\pararsid5196246 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 Updated help text}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5196246 
+\ltrch\fcs0 \insrsid5196246 \hich\af31506\dbch\af31505\loch\f31506 Updated help text
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5196246 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5196246\charrsid5196246 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \b\insrsid14096595\charrsid14096595 \hich\af31506\dbch\af31505\loch\f31506 Fixed in 2.60}{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \b\insrsid14096595 
@@ -238,21 +239,19 @@ It will NOT work with PowerShell V1}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\ins
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f2\fs22\insrsid14096595 \hich\af2\dbch\af31505\loch\f2 o\tab}\hich\af31506\dbch\af31505\loch\f31506 Company Phone
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls13\rin0\lin720\itap0\pararsid14096595 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid14096595 \hich\af31506\dbch\af31505\loch\f31506 Added Function sendemail
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Added Log switch to create a transcript log
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Added Log switch to create a transcri\hich\af31506\dbch\af31505\loch\f31506 pt log
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f2\fs22\insrsid14096595 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls13\ilvl1\rin0\lin1440\itap0\pararsid14096595 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid14096595 \hich\af31506\dbch\af31505\loch\f31506 Added function TranscriptLogging
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls13\rin0\lin720\itap0\pararsid14096595 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid14096595 \hich\af31506\dbch\af31505\loch\f31506 Fixed uninitialized variable for Admin Partitions
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Fixed French wording for Table of Contents 2 (Thanks to David Rouquier)
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Removed Hardware code \hich\af31506\dbch\af31505\loch\f31506 
-as it is not needed for NetScaler
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Removed HTML and Text code as they are not used
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Removed Hardware code as it is not needed for NetScaler
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Removed HTML and Text code a\hich\af31506\dbch\af31505\loch\f31506 s they are not used
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 
 Removed code that made sure all Parameters were set to default values if for some reason they did exist, or values were $Null
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Removed ComputerName code as it is not nee\hich\af31506\dbch\af31505\loch\f31506 
-ded for NetScaler
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 
-Reordered the parameters in the help text and parameter list so they match and are grouped better
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Removed ComputerName code as it is not needed for NetScaler
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Reordered the parameters in the help text an\hich\af31506\dbch\af31505\loch\f31506 
+d parameter list so they match and are grouped better
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\insrsid14096595 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Updated Function ProcessScriptEnd for the new Co\hich\af31506\dbch\af31505\loch\f31506 
 ver Page properties, and Dev, ScriptInfo, Log Parameters
@@ -274,7 +273,7 @@ New table function that now utilizes native word tables. Looks a lot better and 
 \lang1033\langfe1043\langfenp1043\insrsid11485054\charrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 Better support for }{\rtlch\fcs1 \af0 \ltrch\fcs0 \lang1033\langfe1043\langfenp1043\insrsid7095228\charrsid11485054 
 \hich\af31506\dbch\af31505\loch\f31506 multi-language}{\rtlch\fcs1 \af0 \ltrch\fcs0 \lang1033\langfe1043\langfenp1043\insrsid11485054\charrsid11485054 \hich\af31506\dbch\af31505\loch\f31506  Word versions. Will now always utilize cover page and TOC
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \b\lang1043\langfe1043\chbrdr\brdrnone\brdrframe1 \langnp1043\langfenp1043\insrsid11485054\charrsid14096595 
-\hich\af31506\dbch\af31505\loch\f31506 New NetScaler functionality:}{\rtlch\fcs1 \af0 \ltrch\fcs0 \b\lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid14096595 
+\hich\af31506\dbch\af31505\loch\f31506 New NetScaler functiona\hich\af31506\dbch\af31505\loch\f31506 lity:}{\rtlch\fcs1 \af0 \ltrch\fcs0 \b\lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid14096595 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid11485054 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar
 \ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls9\rin0\lin720\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 
 NetScaler Gateway
@@ -308,7 +307,7 @@ Expressions with spaces, quotes, dashes and slashed fixed
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid11485054 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 Grammatical corrections
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\lang1033\langfe1043\langfenp1043\insrsid11485054\charrsid11485054 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\lang1033\langfe1043\langfenp1043\insrsid11485054\charrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 Rechecked all settings like enabled/disabled\hich\af31506\dbch\af31505\loch\f31506  or on/off and corrected when necessary
+\lang1033\langfe1043\langfenp1043\insrsid11485054\charrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 Rechecked all settings like enabled/disabled or on/off and corrected when necessary
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\lang1033\langfe1043\langfenp1043\insrsid11485054\charrsid11485054 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 \hich\f31506 
 Time zone not show correctly when in GMT+\'85.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\fs22\lang1043\langfe1043\langnp1043\langfenp1043\insrsid11485054\charrsid11485054 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 
@@ -326,13 +325,13 @@ Time zone not show correctly when in GMT+\'85.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Global Settings
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Feature and mode state
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Networking
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 IP Address / vLAN / Routing Table / DNS
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 IP Address \hich\af31506\dbch\af31505\loch\f31506 
+/ vLAN / Routing Table / DNS
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Authentication
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Local / LDAP
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Traffic Domain
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Assigned Content Switch / Load Bala
-\hich\af31506\dbch\af31505\loch\f31506 ncer / }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \insrsid7095228\charrsid12284731 \hich\af31506\dbch\af31505\loch\f31506 Service /}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \insrsid12284731\charrsid12284731 
-\hich\af31506\dbch\af31505\loch\f31506  Server
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Assigned Content Switch / Load Balancer / }{\rtlch\fcs1 \af0\afs22 
+\ltrch\fcs0 \insrsid7095228\charrsid12284731 \hich\af31506\dbch\af31505\loch\f31506 Service /}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \insrsid12284731\charrsid12284731 \hich\af31506\dbch\af31505\loch\f31506  Server
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Monitoring
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Certificate
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Content Switches
@@ -346,7 +345,7 @@ Time zone not show correctly when in GMT+\'85.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Service Group
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Assigned Server / monitor
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Server
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Custom Monitor
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScale\hich\af31506\dbch\af31505\loch\f31506 r Custom Monitor
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Policy
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Action
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12284731\charrsid12284731 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 NetScaler Profile}{\rtlch\fcs1 \af0\afs26 \ltrch\fcs0 
@@ -363,37 +362,724 @@ Time zone not show correctly when in GMT+\'85.
 \ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls11\rin0\lin720\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 Save the script as }{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \i\insrsid9980162\charrsid9980162 \hich\af31506\dbch\af31505\loch\f31506 NetScaler_Script_V2_6_Unsigned.ps1}{\rtlch\fcs1 \ai\af0 \ltrch\fcs0 \i\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506  }{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 in your PowerShell scripts folder.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid16011537 \hich\af31506\dbch\af31505\loch\f31506 2.\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16011537 \hich\af31506\dbch\af31505\loch\f31506 Save the Net
-\hich\af31506\dbch\af31505\loch\f31506 Scaler configuration file as ns.conf by following }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15609505 \hich\af31506\dbch\af31505\loch\f31506 
- HYPERLINK "https://support.citrix.com/article/CTX222891" }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15609505 {\*\datafield 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid16011537 \hich\af31506\dbch\af31505\loch\f31506 2.\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16011537 \hich\af31506\dbch\af31505\loch\f31506 
+Save the NetScaler configuration file as ns.conf by following }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid15609505 \hich\af31506\dbch\af31505\loch\f31506  HYPERLINK "https://support.citrix.com/article/CTX222891" }{\rtlch\fcs1 \af0 
+\ltrch\fcs0 \insrsid15609505 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b72000000680074007400700073003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f00430054005800320032003200
-3800390031000000795881f43b1d7f48af2c825dc485276300000000a5ab00032460}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\ul\cf2\insrsid16011537\charrsid15609505 \hich\af37\dbch\af31505\loch\f37 the}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+3800390031000000795881f43b1d7f48af2c825dc485276300000000a5ab0003246002}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\ul\cf2\insrsid16011537\charrsid15609505 \hich\af37\dbch\af31505\loch\f37 the}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\ul\cf2\insrsid7892711\charrsid15609505 \hich\af37\dbch\af31505\loch\f37 se directions}}}\sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid7892711 
 \hich\af31506\dbch\af31505\loch\f31506 : }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16011537 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid16011537\charrsid16011537 \hich\af31506\dbch\af31505\loch\f31506 3.\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16011537\charrsid16011537 \hich\af31506\dbch\af31505\loch\f31506 
 Copy the ns.conf file to your PowerShell scripts folder.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 4.\tab}}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 
 From the PowerShell prompt, change to your PowerShell scripts.
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 5.\tab}\hich\af31506\dbch\af31505\loch\f31506 From the PowerShell prompt, type in:
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 5.\tab}\hich\af31506\dbch\af31505\loch\f31506 From \hich\af31506\dbch\af31505\loch\f31506 
+the PowerShell prompt, type in:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \ai\af0 \ltrch\fcs0 \i\f31506\fs22\insrsid13451403 \hich\af31506\dbch\af31505\loch\f31506 a.\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls11\ilvl1\rin0\lin1440\itap0\pararsid14096595 {
 \rtlch\fcs1 \ai\af0 \ltrch\fcs0 \i\insrsid13451403 .\\}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9980162\charrsid9980162 \hich\af31506\dbch\af31505\loch\f31506  NetScaler_Script_V2_6_Unsigned.ps1}{\rtlch\fcs1 \ai\af0 \ltrch\fcs0 
 \i\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506  }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 and press }{\rtlch\fcs1 \ai\af0 \ltrch\fcs0 
 \i\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 Enter}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 6.\tab}}\pard \ltrpar
-\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls11\rin0\lin720\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 By default, a Microsoft Word doc
-\hich\af31506\dbch\af31505\loch\f31506 ument is created}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1925247 \hich\af31506\dbch\af31505\loch\f31506  named NetScaler.docx}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 .
+\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls11\rin0\lin720\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 By default, a Microsoft Word document is created}{
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1925247 \hich\af31506\dbch\af31505\loch\f31506  named NetScaler.docx}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f31506\fs22\insrsid11488686\charrsid13987238 \hich\af31506\dbch\af31505\loch\f31506 7.\tab}\hich\af31506\dbch\af31505\loch\f31506 If you use the \hich\f31506 \endash \loch\f31506 
 PDF option, a PDF file is created}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1925247 \hich\af31506\dbch\af31505\loch\f31506  named NetScaler.pdf}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686\charrsid13987238 .
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14096595 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14096595 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 \hich\af31506\dbch\af31505\loch\f31506 Full help text is available.
+\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 \hich\af31506\dbch\af31505\loch\f31506 F\hich\af31506\dbch\af31505\loch\f31506 ull help text is available.
 \par 
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13451403 \hich\af31506\dbch\af31505\loch\f31506 Get-Help .\\NetScaler_}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9980162 \hich\af31506\dbch\af31505\loch\f31506 Script_}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13451403 
 \hich\af31506\dbch\af31505\loch\f31506 V}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11485054 \hich\af31506\dbch\af31505\loch\f31506 2}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9980162 \hich\af31506\dbch\af31505\loch\f31506 _6_Unsigned}{\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid11488686 \hich\af31506\dbch\af31505\loch\f31506 .ps1 \hich\f31506 \endash \loch\f31506 full
 \par 
 \par \hich\af31506\dbch\af31505\loch\f31506 The help text explains a}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13451403 \hich\af31506\dbch\af31505\loch\f31506 ll the parameters the }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
-\hich\af31506\dbch\af31505\loch\f31506 script accept\hich\af31506\dbch\af31505\loch\f31506 s.
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
+\hich\af31506\dbch\af31505\loch\f31506 script accepts.
+\par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid1538239 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1538239 \page }{\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid1538239 \hich\af31506\dbch\af31505\loch\f31506 
+Help Text}{\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid1538239 
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid1538239 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
+\ltrch\fcs0 \insrsid1538239 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \\\hich\af2\dbch\af31505\loch\f2 
+NetScaler_Script_v2_6_unsigned.ps1
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix NetScaler configuration using Microsoft Word.
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 SYNTAX
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \\\hich\af2\dbch\af31505\loch\f2 
+NetScaler_Script_v2_6_unsigned.ps1 [-AddDateTime] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \\\hich\af2\dbch\af31505\loch\f2 
+NetScal\hich\af2\dbch\af31505\loch\f2 er_Script_v2_6_unsigned.ps1 [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] [-PDF] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] -SmtpServe\hich\af2\dbch\af31505\loch\f2 
+r <String> [-SmtpPort <Int32>] [-UseSSL] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-Log] [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \\\hich\af2\dbch\af31505\loch\f2 
+NetScaler_Script_v2_6_unsigned.ps1 [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-Compan\hich\af2\dbch\af31505\loch\f2 yName <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \\\hich\af2\dbch\af31505\loch\f2 
+NetScaler_Script_v2_6_unsigned.ps1 [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-Co\hich\af2\dbch\af31505\loch\f2 mpanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
+\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  complete inventory of a Citrix NetScaler configuration using Microsoft Word }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 and PowerShell.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word document named after the Citrix NetScaler Configuration.
+\par \hich\af2\dbch\af31505\loch\f2     Document includes a Cover Page, Table of Contents}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 
+ and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Includes support \hich\af2\dbch\af31505\loch\f2 for the following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2         Catalan
+\par \hich\af2\dbch\af31505\loch\f2         Chinese
+\par \hich\af2\dbch\af31505\loch\f2         Danish
+\par \hich\af2\dbch\af31505\loch\f2         Dutch
+\par \hich\af2\dbch\af31505\loch\f2         English
+\par \hich\af2\dbch\af31505\loch\f2         Finnish
+\par \hich\af2\dbch\af31505\loch\f2         French
+\par \hich\af2\dbch\af31505\loch\f2         German
+\par \hich\af2\dbch\af31505\loch\f2         Norwegian
+\par \hich\af2\dbch\af31505\loch\f2         Portuguese
+\par \hich\af2\dbch\af31505\loch\f2         Spanish
+\par \hich\af2\dbch\af31505\loch\f2         Swedish
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\hich\af2\dbch\af31505\loch\f2  the Cover Page has the Address field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 T\hich\af2\dbch\af31505\loch\f2 iles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?          \hich\af2\dbch\af31505\loch\f2           named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\hich\af2\dbch\af31505\loch\f2  the Cover Page has the Email field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 Page if}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\hich\af2\dbch\af31505\loch\f2  the Cover Page has the Fax field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of CN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company\hich\af2\dbch\af31505\loch\f2  Phone to use for the Cover Page if the Cover Page has the Phone field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Valid input is:
+\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works\hich\af2\dbch\af31505\loch\f2  in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 36 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010.\hich\af2\dbch\af31505\loch\f2  Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Work\hich\af2\dbch\af31505\loch\f2 s)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Si\hich\af2\dbch\af31505\loch\f2 deline.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       The default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output\hich\af2\dbch\af31505\loch\f2  format is selected.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchP\hich\af2\dbch\af31505\loch\f2 arameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Add\hich\af2\dbch\af31505\loch\f2 s a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is di\hich\af2\dbch\af31505\loch\f2 sabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?             \hich\af2\dbch\af31505\loch\f2        named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         The default is 25.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    The default is False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?             \hich\af2\dbch\af31505\loch\f2        named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -To <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the be\hich\af2\dbch\af31505\loch\f2 ginning of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to\hich\af2\dbch\af31505\loch\f2  a text file.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 https:/g\hich\af2\dbch\af31505\loch\f2 
+o.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 ).
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 INPUTS
+\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
+\par \hich\af2\dbch\af31505\loch\f2     This script creates a Word or PDF document.
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2 NOTES
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         NAME: NetScaler_Script_v2_6_unsigned.\hich\af2\dbch\af31505\loch\f2 ps1
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.62
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Michael B. Smith, Iain Brighton, Jeff Wouters, Barry Schiffer
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February 18, 2022
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Barry\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Barry Schiffer for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript \hich\af2\dbch\af31505\loch\f2 >.\\NetScaler_Script_v2_6.ps1 -PDF
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\U\hich\af2\dbch\af31505\loch\f2 serInfo\\Company="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Barry Schiffer for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\NetScaler_Script_v2_6.ps1 -CompanyName "Barry Schiffer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Consulting" -CoverPage "Mod" -UserName "Barry Schiffer"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Barry Schiffer Consulting\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Barry Schiffer for the User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\NetScaler_Script_v2_6.ps1 -CN "Barry Schiffer Consu\hich\af2\dbch\af31505\loch\f2 lting" -CP }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 "Mod" -UN "Barry Schiffer"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Barry Schiffer Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Barry Schiffer for the User Name (alias UN).
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------\hich\af2\dbch\af31505\loch\f2 - EXAMPLE 5 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1 -AddDateTime
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Barry Schiffer for the Company N\hich\af2\dbch\af31505\loch\f2 ame.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename w\hich\af2\dbch\af31505\loch\f2 ill be Script_Template_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1 -PDF -AddDateTime
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Barry }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Schiffer"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Barry Schiffer for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be Script_Template_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.PDF
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\NetScaler_Script_v2_6.ps1 -CompanyName "Sherloc\hich\af2\dbch\af31505\loch\f2 k Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -CoverPage Exposure -UserName "Dr. Watson"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -CompanyAddress "221B Baker }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Street, London, England"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -CompanyFax "+44 1753 276600"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -CompanyPhone "+44 1753 276200"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Co\hich\af2\dbch\af31505\loch\f2 mpany Name.
+\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\NetScaler_Script_v2_6.ps1 -CompanyName "Sherlock Holmes }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -CoverPage Facet -UserName "Dr. Watson"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@SherlockHolmes.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company \hich\af2\dbch\af31505\loch\f2 Name.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Scri\hich\af2\dbch\af31505\loch\f2 pt_v2_6.ps1 -Folder \\\\FileServer\\ShareName
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Web\hich\af2\dbch\af31505\loch\f2 ster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1 -Dev -ScriptInfo -Log
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates the default report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  text file named NSInventoryScriptErrors_yyyyMMddTHHmmssffff.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named NSInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and ot\hich\af2\dbch\af31505\loch\f2 her basic information.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
+\par \hich\af2\dbch\af31505\loch\f2     NSDocScriptTranscript_yyyyMMddTHHmmssffff.txt.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1 -SmtpS\hich\af2\dbch\af31505\loch\f2 erver mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and does not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to se\hich\af2\dbch\af31505\loch\f2 nd an email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1 -SmtpServer mailrelay.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1538239\charrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tl\hich\af2\dbch\af31505\loch\f2 d -To ITGroup@domain.tld
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay \hich\af2\dbch\af31505\loch\f2 server requires the From email account
+\par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and does not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G \hich\af2\dbch\af31505\loch\f2 SUITE SMTP RELAY***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     account.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\NetScaler_Script_v2_6.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid1538239\charrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+{\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
+2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunctio\hich\af2\dbch\af31505\loch\f2 
+n-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\headery708\footery708\colsx708\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\Net\hich\af2\dbch\af31505\loch\f2 Scaler_Script_v2_6.ps1 -SmtpServer smtp.office365.com -SmtpPort }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebs\hich\af2\dbch\af31505\loch\f2 ter.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C\hich\af2\dbch\af31505\loch\f2 :\\PSScript >.\\NetScaler_Script_v2_6.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@g\hich\af2\dbch\af31505\loch\f2 mail.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1538239\charrsid1538239 \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid11488686\charrsid1538239 
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid14697282\charrsid11488686 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
@@ -514,8 +1200,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000000052
-d3a5f3b4d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000002010
+811ecd24d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}


### PR DESCRIPTION
#Version 2.62 18-Feb-2022
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed $Null comparisons that were on the wrong side
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated Functions CheckWordPrereq and SendEmail to the latest version
#	Updated the help text
#	Updated the ReadMe file